### PR TITLE
Increased Python version to allow 3.11.2

### DIFF
--- a/apis_highlighter/urls.py
+++ b/apis_highlighter/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import path
 
 app_name = "apis_highlighter"
 
@@ -7,4 +7,4 @@ urlpatterns = []
 
 if 'annotator agreement' in getattr(settings, "APIS_COMPONENTS", []):
     from apis_highlighter.views import ComputeAgreement
-    urlpatterns.append(url(r'^agreement/$', ComputeAgreement.as_view(), name='agreement'))
+    urlpatterns.append(path(r'^agreement/$', ComputeAgreement.as_view(), name='agreement'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Matthias Schlögl <m.schloegl@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.6, <3.9"
+python = ">=3.6, <3.12"
 apis-core = ">=0.16.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Updates Python version to allow `3.11.2`. Requirement for updating Python and Django versions. See:

https://github.com/acdh-oeaw/apis-core-rdf/pull/41
https://github.com/acdh-oeaw/apis-rdf-devops/pull/42
https://github.com/acdh-oeaw/apis-bibsonomy/pull/14
