### PR TITLE
chore: update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ authors = ["Matthias Schlögl <m.schloegl@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.7, <3.11"
-apis-core = ">=0.16.0"
+python = ">=3.8"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Remove apis-core dependency and update minimal Python dependency to
version 3.8
