### PR TITLE
birger/update deps

### DIFF
--- a/apis_highlighter/urls.py
+++ b/apis_highlighter/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import path
 
 app_name = "apis_highlighter"
 
@@ -7,4 +7,4 @@ urlpatterns = []
 
 if 'annotator agreement' in getattr(settings, "APIS_COMPONENTS", []):
     from apis_highlighter.views import ComputeAgreement
-    urlpatterns.append(url(r'^agreement/$', ComputeAgreement.as_view(), name='agreement'))
+    urlpatterns.append(path(r'^agreement/$', ComputeAgreement.as_view(), name='agreement'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ authors = ["Matthias Schlögl <m.schloegl@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.7, <3.11"
-apis-core = ">=0.16.0"
+python = ">=3.7, <3.12"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- refactors to path rather than url for compatibility
- chore: Bump Python version and drop apis-core dependency
